### PR TITLE
Fix to still render text if input missing

### DIFF
--- a/packages/generator/src/generate.ts
+++ b/packages/generator/src/generate.ts
@@ -51,7 +51,8 @@ const generate = async (props: GenerateProps) => {
         const schema = schemaObj[key];
         const value = inputObj[key];
 
-        if (!schema || !value) {
+        // it's possible to have an empty value here... (shouldn't really be, but is)
+        if (!schema) {
           continue;
         }
 


### PR DESCRIPTION
This should only impact in-browser previews, ideally we wouldn't render empty content but it looks weird if you forgot to add something and then the whole content is missing